### PR TITLE
Upgrade to ODD SDK 0.37

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-__Bundler testing facility for [webnative](https://github.com/fission-suite/webnative)__.
+__Bundler testing facility for [ODD SDK](https://github.com/oddsdk/ts-odd)__.
 
 ```shell
 npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "odd-bundler-test",
       "dependencies": {
         "@oddjs/odd": "0.37.0"
       },
@@ -555,13 +556,13 @@
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
-      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
+      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
     "node_modules/@lezer/common": {
@@ -2142,9 +2143,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "0.0.51",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
       "dev": true
     },
     "node_modules/@types/json-schema": {
@@ -3405,9 +3406,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-      "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.2.1.tgz",
+      "integrity": "sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg==",
       "dev": true
     },
     "node_modules/esbuild": {
@@ -4371,9 +4372,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -5418,9 +5419,9 @@
       "dev": true
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -5721,9 +5722,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
       "dev": true,
       "dependencies": {
         "randombytes": "^2.1.0"
@@ -5951,9 +5952,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.14.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+      "version": "5.16.9",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.9.tgz",
+      "integrity": "sha512-HPa/FdTB9XGI2H1/keLFZHxl6WNvAI4YalHGtDQTlMnJcoqSab1UwL4l1hGEhs6/GmLHBZIg/YgB++jcbzoOEg==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
@@ -5969,16 +5970,16 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
-      "integrity": "sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.7.tgz",
+      "integrity": "sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.7",
+        "@jridgewell/trace-mapping": "^0.3.17",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
-        "serialize-javascript": "^6.0.0",
-        "terser": "^5.7.2"
+        "serialize-javascript": "^6.0.1",
+        "terser": "^5.16.5"
       },
       "engines": {
         "node": ">= 10.13.0"
@@ -6129,9 +6130,9 @@
       "integrity": "sha512-TaVmGEBt0fhxiNJMGphBfB+oGvUxFs8KgGvgl8d3C+GWtrFcvXdJ2196eg+dYhmSFClmgFfSfJEklo+SZzdNuw=="
     },
     "node_modules/undici": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
-      "integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
+      "version": "5.21.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.2.tgz",
+      "integrity": "sha512-f6pTQ9RF4DQtwoWSaC42P/NKlUjvezVvd9r155ohqkwFNRyBKM3f3pcty3ouusefNRyM25XhIQEbeQ46sZDJfQ==",
       "peer": true,
       "dependencies": {
         "busboy": "^1.6.0"
@@ -6316,13 +6317,13 @@
       "dev": true
     },
     "node_modules/webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.79.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.79.0.tgz",
+      "integrity": "sha512-3mN4rR2Xq+INd6NnYuL9RC9GAmc1ROPKJoHhrZ4pAjdMFEkJJWrsPw8o2JjCIyQyTu7rTXYn4VG6OpyB3CobZg==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^0.0.51",
+        "@types/estree": "^1.0.0",
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/wasm-edit": "1.11.1",
         "@webassemblyjs/wasm-parser": "1.11.1",
@@ -6331,7 +6332,7 @@
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^5.10.0",
-        "es-module-lexer": "^0.9.0",
+        "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
@@ -6342,7 +6343,7 @@
         "neo-async": "^2.6.2",
         "schema-utils": "^3.1.0",
         "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.1.3",
+        "terser-webpack-plugin": "^5.3.7",
         "watchpack": "^2.4.0",
         "webpack-sources": "^3.2.3"
       },
@@ -6857,13 +6858,13 @@
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
-      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
+      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
       "dev": true,
       "requires": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
     "@lezer/common": {
@@ -7929,9 +7930,9 @@
       }
     },
     "@types/estree": {
-      "version": "0.0.51",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
       "dev": true
     },
     "@types/json-schema": {
@@ -8944,9 +8945,9 @@
       }
     },
     "es-module-lexer": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-      "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.2.1.tgz",
+      "integrity": "sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg==",
       "dev": true
     },
     "esbuild": {
@@ -9643,9 +9644,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "just-safe-get": {
@@ -10392,9 +10393,9 @@
       }
     },
     "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "dev": true
     },
     "queue-microtask": {
@@ -10593,9 +10594,9 @@
       "dev": true
     },
     "serialize-javascript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
       "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
@@ -10761,9 +10762,9 @@
       "dev": true
     },
     "terser": {
-      "version": "5.14.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+      "version": "5.16.9",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.9.tgz",
+      "integrity": "sha512-HPa/FdTB9XGI2H1/keLFZHxl6WNvAI4YalHGtDQTlMnJcoqSab1UwL4l1hGEhs6/GmLHBZIg/YgB++jcbzoOEg==",
       "dev": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.2",
@@ -10781,16 +10782,16 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
-      "integrity": "sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.7.tgz",
+      "integrity": "sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==",
       "dev": true,
       "requires": {
-        "@jridgewell/trace-mapping": "^0.3.7",
+        "@jridgewell/trace-mapping": "^0.3.17",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
-        "serialize-javascript": "^6.0.0",
-        "terser": "^5.7.2"
+        "serialize-javascript": "^6.0.1",
+        "terser": "^5.16.5"
       }
     },
     "throttle-debounce": {
@@ -10903,9 +10904,9 @@
       }
     },
     "undici": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
-      "integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
+      "version": "5.21.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.2.tgz",
+      "integrity": "sha512-f6pTQ9RF4DQtwoWSaC42P/NKlUjvezVvd9r155ohqkwFNRyBKM3f3pcty3ouusefNRyM25XhIQEbeQ46sZDJfQ==",
       "peer": true,
       "requires": {
         "busboy": "^1.6.0"
@@ -11021,13 +11022,13 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.79.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.79.0.tgz",
+      "integrity": "sha512-3mN4rR2Xq+INd6NnYuL9RC9GAmc1ROPKJoHhrZ4pAjdMFEkJJWrsPw8o2JjCIyQyTu7rTXYn4VG6OpyB3CobZg==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^0.0.51",
+        "@types/estree": "^1.0.0",
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/wasm-edit": "1.11.1",
         "@webassemblyjs/wasm-parser": "1.11.1",
@@ -11036,7 +11037,7 @@
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^5.10.0",
-        "es-module-lexer": "^0.9.0",
+        "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
@@ -11047,7 +11048,7 @@
         "neo-async": "^2.6.2",
         "schema-utils": "^3.1.0",
         "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.1.3",
+        "terser-webpack-plugin": "^5.3.7",
         "watchpack": "^2.4.0",
         "webpack-sources": "^3.2.3"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "webnative-bundler-test",
+  "name": "odd-bundler-test",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
-        "webnative": "0.35.0"
+        "@oddjs/odd": "0.37.0"
       },
       "devDependencies": {
         "copyfiles": "^2.4.1",
@@ -964,6 +964,37 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@oddjs/odd": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@oddjs/odd/-/odd-0.37.0.tgz",
+      "integrity": "sha512-QvDIRGjm8UXjv6/GD/xw39rHmouaYefl8ipJ4En++SoCXHcfInq4ZbgE0APmlxjBSAksJX7JGipkkkpe9gCc8A==",
+      "dependencies": {
+        "@ipld/dag-cbor": "^8.0.0",
+        "@ipld/dag-pb": "^3.0.1",
+        "@libp2p/interface-keys": "^1.0.4",
+        "@libp2p/peer-id": "^1.1.17",
+        "@multiformats/multiaddr": "^11.1.0",
+        "blockstore-core": "^2.0.2",
+        "blockstore-datastore-adapter": "^4.0.0",
+        "datastore-core": "^8.0.2",
+        "datastore-level": "^9.0.4",
+        "events": "^3.3.0",
+        "fission-bloom-filters": "1.7.1",
+        "ipfs-core-types": "0.13.0",
+        "ipfs-repo": "^16.0.0",
+        "keystore-idb": "^0.15.5",
+        "localforage": "^1.10.0",
+        "multiformats": "^10.0.2",
+        "one-webcrypto": "^1.0.3",
+        "throttle-debounce": "^3.0.1",
+        "tweetnacl": "^1.0.3",
+        "uint8arrays": "^3.0.0",
+        "wnfs": "0.1.7"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@parcel/bundler-default": {
@@ -6284,37 +6315,6 @@
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
       "dev": true
     },
-    "node_modules/webnative": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.35.0.tgz",
-      "integrity": "sha512-Simk76/VMLmet+KvFXe3msTw69zQt0n7kx+dE9yauITkyrRlAyPOO88yaPb8gBXCRmcQkFMAffJIPL21vZ/u5Q==",
-      "dependencies": {
-        "@ipld/dag-cbor": "^8.0.0",
-        "@ipld/dag-pb": "^3.0.1",
-        "@libp2p/interface-keys": "^1.0.4",
-        "@libp2p/peer-id": "^1.1.17",
-        "@multiformats/multiaddr": "^11.1.0",
-        "blockstore-core": "^2.0.2",
-        "blockstore-datastore-adapter": "^4.0.0",
-        "datastore-core": "^8.0.2",
-        "datastore-level": "^9.0.4",
-        "events": "^3.3.0",
-        "fission-bloom-filters": "1.7.1",
-        "ipfs-core-types": "0.13.0",
-        "ipfs-repo": "^16.0.0",
-        "keystore-idb": "^0.15.5",
-        "localforage": "^1.10.0",
-        "multiformats": "^10.0.2",
-        "one-webcrypto": "^1.0.3",
-        "throttle-debounce": "^3.0.1",
-        "tweetnacl": "^1.0.3",
-        "uint8arrays": "^3.0.0",
-        "wnfs": "0.1.7"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/webpack": {
       "version": "5.75.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
@@ -7149,6 +7149,34 @@
             "multiformats": "^10.0.0"
           }
         }
+      }
+    },
+    "@oddjs/odd": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@oddjs/odd/-/odd-0.37.0.tgz",
+      "integrity": "sha512-QvDIRGjm8UXjv6/GD/xw39rHmouaYefl8ipJ4En++SoCXHcfInq4ZbgE0APmlxjBSAksJX7JGipkkkpe9gCc8A==",
+      "requires": {
+        "@ipld/dag-cbor": "^8.0.0",
+        "@ipld/dag-pb": "^3.0.1",
+        "@libp2p/interface-keys": "^1.0.4",
+        "@libp2p/peer-id": "^1.1.17",
+        "@multiformats/multiaddr": "^11.1.0",
+        "blockstore-core": "^2.0.2",
+        "blockstore-datastore-adapter": "^4.0.0",
+        "datastore-core": "^8.0.2",
+        "datastore-level": "^9.0.4",
+        "events": "^3.3.0",
+        "fission-bloom-filters": "1.7.1",
+        "ipfs-core-types": "0.13.0",
+        "ipfs-repo": "^16.0.0",
+        "keystore-idb": "^0.15.5",
+        "localforage": "^1.10.0",
+        "multiformats": "^10.0.2",
+        "one-webcrypto": "^1.0.3",
+        "throttle-debounce": "^3.0.1",
+        "tweetnacl": "^1.0.3",
+        "uint8arrays": "^3.0.0",
+        "wnfs": "0.1.7"
       }
     },
     "@parcel/bundler-default": {
@@ -10991,34 +11019,6 @@
       "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
       "dev": true
-    },
-    "webnative": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.35.0.tgz",
-      "integrity": "sha512-Simk76/VMLmet+KvFXe3msTw69zQt0n7kx+dE9yauITkyrRlAyPOO88yaPb8gBXCRmcQkFMAffJIPL21vZ/u5Q==",
-      "requires": {
-        "@ipld/dag-cbor": "^8.0.0",
-        "@ipld/dag-pb": "^3.0.1",
-        "@libp2p/interface-keys": "^1.0.4",
-        "@libp2p/peer-id": "^1.1.17",
-        "@multiformats/multiaddr": "^11.1.0",
-        "blockstore-core": "^2.0.2",
-        "blockstore-datastore-adapter": "^4.0.0",
-        "datastore-core": "^8.0.2",
-        "datastore-level": "^9.0.4",
-        "events": "^3.3.0",
-        "fission-bloom-filters": "1.7.1",
-        "ipfs-core-types": "0.13.0",
-        "ipfs-repo": "^16.0.0",
-        "keystore-idb": "^0.15.5",
-        "localforage": "^1.10.0",
-        "multiformats": "^10.0.2",
-        "one-webcrypto": "^1.0.3",
-        "throttle-debounce": "^3.0.1",
-        "tweetnacl": "^1.0.3",
-        "uint8arrays": "^3.0.0",
-        "wnfs": "0.1.7"
-      }
     },
     "webpack": {
       "version": "5.75.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "vite": "vite build src --emptyOutDir --outDir ../dist/ --config vite.config.js",
     "vite-dev": "vite src --config vite.config.js",
     "webpack": "webpack",
-    "worker-importscript": "copyfiles --flat node_modules/webnative/dist/**/*.* build/vendor/webnative/ && webpack --config webpack.worker.config.js && copyfiles --flat src/worker-non-module.html build/",
+    "worker-importscript": "copyfiles --flat node_modules/@oddjs/odd/dist/**/*.* build/vendor/odd/ && webpack --config webpack.worker.config.js && copyfiles --flat src/worker-non-module.html build/",
     "test": "rimraf dist && rimraf build && \"$npm_execpath\" run estrella && \"$npm_execpath\" run vite && \"$npm_execpath\" run webpack && \"$npm_execpath\" run copy-html"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "webpack-cli": "^5.0.1"
   },
   "dependencies": {
-    "webnative": "0.35.0"
+    "@oddjs/odd": "0.37.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,29 +1,29 @@
-import * as wn from "webnative"
+import * as odd from "@oddjs/odd"
 
   ; (async () => {
     const config = { namespace: "bundler-test" }
 
-    const crypto = await wn.defaultCryptoComponent(config)
-    const manners = wn.defaultMannersComponent(config)
-    const storage = wn.defaultStorageComponent(config)
+    const crypto = await odd.defaultCryptoComponent(config)
+    const manners = odd.defaultMannersComponent(config)
+    const storage = odd.defaultStorageComponent(config)
 
-    const depot = await wn.defaultDepotComponent({ storage }, config)
-    const reference = await wn.defaultReferenceComponent({ crypto, manners, storage })
+    const depot = await odd.defaultDepotComponent({ storage }, config)
+    const reference = await odd.defaultReferenceComponent({ crypto, manners, storage })
 
-    const fs = await wn.FileSystem.empty({
-      account: { rootDID: await wn.did.agent(crypto) },
+    const fs = await odd.FileSystem.empty({
+      account: { rootDID: await odd.did.agent(crypto) },
       dependencies: { crypto, depot, manners, reference, storage },
       localOnly: true
     })
 
-    const privatePath = wn.path.file(
-      wn.path.Branch.Private,
+    const privatePath = odd.path.file(
+      odd.path.RootBranch.Private,
       "testing",
       "write.txt"
     )
 
-    const publicPath = wn.path.directory(
-      wn.path.Branch.Public,
+    const publicPath = odd.path.directory(
+      odd.path.RootBranch.Public,
       "testing",
       "nested"
     )
@@ -32,9 +32,9 @@ import * as wn from "webnative"
     const contents = await fs.read(privatePath)
 
     console.log(contents)
-    console.log(await fs.ls(wn.path.parent(privatePath)))
+    console.log(await fs.ls(odd.path.parent(privatePath)))
 
     await fs.mkdir(publicPath)
 
-    console.log(await fs.ls(wn.path.parent(publicPath)))
+    console.log(await fs.ls(odd.path.parent(publicPath)))
   })()

--- a/src/worker-importscript.js
+++ b/src/worker-importscript.js
@@ -1,17 +1,17 @@
-importScripts("vendor/webnative/index.umd.min.js")
+importScripts("vendor/odd/index.umd.min.js")
 
-const wn = webnative
+const odd = oddjs
 
   ; (async () => {
     const fs = await wn.fs.empty({ localOnly: true })
     const privatePath = wn.path.file(
-      wn.path.Branch.Private,
+      wn.path.RootBranch.Private,
       "testing",
       "write.txt"
     )
 
     const publicPath = wn.path.directory(
-      wn.path.Branch.Public,
+      wn.path.RootBranch.Public,
       "testing",
       "nested"
     )

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,5 +9,8 @@ module.exports = {
     },
     optimization: {
         minimize: false,
+    },
+    performance: {
+        hints: false
     }
 }


### PR DESCRIPTION
This PR upgrades to the ODD SDK at 0.37. The webpack performance hints were also disabled here to reduce noise when running the tests.